### PR TITLE
fix: 이벤트 만료 기준을 생성 날짜에서 시작 날짜로 변경

### DIFF
--- a/src/main/java/eusyaeusya/gmg/domain/event/EventScheduler.java
+++ b/src/main/java/eusyaeusya/gmg/domain/event/EventScheduler.java
@@ -8,7 +8,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 
 @Slf4j
@@ -23,8 +23,8 @@ public class EventScheduler {
     public void expireEvents() {
         log.info("만료된 모임 비활성화 스케줄러 실행");
 
-        LocalDateTime threshold = LocalDateTime.now().minusDays(Event.EXPIRATION_DAYS);
-        List<Event> expiredEvents = eventRepository.findByStatusNotExpiredAndCreatedAtBefore(threshold);
+        LocalDate threshold = LocalDate.now().minusDays(Event.EXPIRATION_DAYS);
+        List<Event> expiredEvents = eventRepository.findByStatusNotExpiredAndDateStartBefore(threshold);
 
         if (expiredEvents.isEmpty()) {
             log.info("만료 처리할 모임이 없습니다.");
@@ -33,8 +33,8 @@ public class EventScheduler {
 
         for (Event event : expiredEvents) {
             event.expire();
-            log.info("모임 만료 처리: id={}, hashUrl={}, createdAt={}",
-                    event.getId(), event.getHashUrl(), event.getCreatedAt());
+            log.info("모임 만료 처리: id={}, hashUrl={}, dateStart={}",
+                    event.getId(), event.getHashUrl(), event.getDateStart());
         }
 
         log.info("총 {}개의 모임이 만료 처리되었습니다.", expiredEvents.size());

--- a/src/main/java/eusyaeusya/gmg/domain/event/entity/Event.java
+++ b/src/main/java/eusyaeusya/gmg/domain/event/entity/Event.java
@@ -204,10 +204,10 @@ public class Event extends BaseTimeEntity {
         if (status == EventStatus.EXPIRED) {
             return true;
         }
-        if (createdAt == null) {
+        if (dateStart == null) {
             return false;
         }
-        return createdAt.plusDays(EXPIRATION_DAYS).isBefore(java.time.LocalDateTime.now());
+        return dateStart.plusDays(EXPIRATION_DAYS).isBefore(LocalDate.now());
     }
 
     public void expire() {

--- a/src/main/java/eusyaeusya/gmg/domain/event/repository/EventRepository.java
+++ b/src/main/java/eusyaeusya/gmg/domain/event/repository/EventRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -18,6 +18,6 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     @Query("SELECT e FROM Event e WHERE e.hashUrl =:hashUrl")
     Optional<Event> findByHashUrlWithLock(@Param("hashUrl") String hashUrl);
 
-    @Query("SELECT e FROM Event e WHERE e.status != 'EXPIRED' AND e.createdAt < :threshold")
-    List<Event> findByStatusNotExpiredAndCreatedAtBefore(@Param("threshold") LocalDateTime threshold);
+    @Query("SELECT e FROM Event e WHERE e.status != 'EXPIRED' AND e.dateStart < :threshold")
+    List<Event> findByStatusNotExpiredAndDateStartBefore(@Param("threshold") LocalDate threshold);
 }

--- a/src/test/java/eusyaeusya/gmg/domain/event/EventSchedulerTest.java
+++ b/src/test/java/eusyaeusya/gmg/domain/event/EventSchedulerTest.java
@@ -9,7 +9,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -26,14 +26,14 @@ class EventSchedulerTest {
     private EventScheduler eventScheduler;
 
     @Test
-    @DisplayName("7일이 지난 모임들을 EXPIRED 상태로 변경한다")
+    @DisplayName("이벤트 시작 날짜 기준 7일이 지난 모임들을 EXPIRED 상태로 변경한다")
     void expireEvents_success() {
         // given
         Event event1 = mock(Event.class);
         Event event2 = mock(Event.class);
         List<Event> expiredEvents = List.of(event1, event2);
 
-        given(eventRepository.findByStatusNotExpiredAndCreatedAtBefore(any(LocalDateTime.class)))
+        given(eventRepository.findByStatusNotExpiredAndDateStartBefore(any(LocalDate.class)))
                 .willReturn(expiredEvents);
 
         // when
@@ -42,21 +42,21 @@ class EventSchedulerTest {
         // then
         verify(event1, times(1)).expire();
         verify(event2, times(1)).expire();
-        verify(eventRepository, times(1)).findByStatusNotExpiredAndCreatedAtBefore(any(LocalDateTime.class));
+        verify(eventRepository, times(1)).findByStatusNotExpiredAndDateStartBefore(any(LocalDate.class));
     }
 
     @Test
     @DisplayName("만료할 모임이 없으면 아무 작업도 하지 않는다")
     void expireEvents_noAction_whenNoExpiredEvents() {
         // given
-        given(eventRepository.findByStatusNotExpiredAndCreatedAtBefore(any(LocalDateTime.class)))
+        given(eventRepository.findByStatusNotExpiredAndDateStartBefore(any(LocalDate.class)))
                 .willReturn(List.of());
 
         // when
         eventScheduler.expireEvents();
 
         // then
-        verify(eventRepository, times(1)).findByStatusNotExpiredAndCreatedAtBefore(any(LocalDateTime.class));
+        verify(eventRepository, times(1)).findByStatusNotExpiredAndDateStartBefore(any(LocalDate.class));
         verifyNoMoreInteractions(eventRepository);
     }
 }


### PR DESCRIPTION
## Summary
- 이벤트 만료 처리 기준을 `createdAt`(생성 날짜)에서 `dateStart`(이벤트 시작 날짜)로 변경
- EventScheduler, EventRepository, Event 엔티티의 `isExpired()` 메서드 수정
- 관련 테스트 코드 업데이트

## 변경 내용
- `EventRepository`: `findByStatusNotExpiredAndCreatedAtBefore` → `findByStatusNotExpiredAndDateStartBefore`
- `EventScheduler`: `LocalDateTime` → `LocalDate` 사용, 로그 메시지에 `dateStart` 출력
- `Event.isExpired()`: `createdAt` 대신 `dateStart` 기준으로 만료 여부 판단

## Test plan
- [ ] EventSchedulerTest 통과 확인
- [ ] 이벤트 시작 날짜 기준 7일 후 만료 처리 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)